### PR TITLE
Fix WORKDIR and change ADD to COPY

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM python:3.8-alpine
-MAINTAINER Max Meinhold <mxmeinhold@gmail.com>
+LABEL maintainer="Max Meinhold <mxmeinhold@gmail.com>"
 
 WORKDIR /opt/demo
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,13 @@
 FROM python:3.8-alpine
 MAINTAINER Max Meinhold <mxmeinhold@gmail.com>
 
-RUN mkdir /opt/demo
-
-ADD requirements.txt /opt/demo
-
 WORKDIR /opt/demo
+
+COPY requirements.txt .
 
 RUN pip install -r requirements.txt
 
-ADD . /opt/demo
+COPY . .
 
 RUN ln -sf /usr/share/zoneinfo/America/New_York /etc/localtime
 


### PR DESCRIPTION
Using WORKDIR automatically creates the directory and moves to that directory. This means all COPY/ADDs will be relative to that.
Also, it is Docker best practice to use COPY instead of ADD because COPY is more transparent, as it does not have some additional behavior that ADD has. For more information, see https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#add-or-copy