### PR TITLE
do timezone stuff the right way

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,11 @@
 FROM python:3.8-alpine
 LABEL maintainer="Max Meinhold <mxmeinhold@gmail.com>"
 
+RUN apk add tzdata && \
+    cp /usr/share/zoneinfo/America/New_York /etc/localtime && \
+    echo 'America/New_York' > /etc/timezone && \
+    apk del tzdata
+
 WORKDIR /opt/demo
 
 COPY requirements.txt .
@@ -8,7 +13,5 @@ COPY requirements.txt .
 RUN pip install -r requirements.txt
 
 COPY . .
-
-RUN ln -sf /usr/share/zoneinfo/America/New_York /etc/localtime
 
 CMD ["gunicorn", "demo:APP", "--bind=0.0.0.0:8080", "--access-logfile=-"]


### PR DESCRIPTION
Previously no time zone file existed on the container. See https://wiki.alpinelinux.org/wiki/Setting_the_timezone